### PR TITLE
:sparkles: [#2] -- implement type definition for content component

### DIFF
--- a/src/formio/components/content.ts
+++ b/src/formio/components/content.ts
@@ -1,0 +1,40 @@
+import {DisplayConfig, LayoutComponentSchema, OFExtensions} from '..';
+
+/**
+ * The content component schema, intended for WYSIWYG content.
+ *
+ * The content component type is a mechanism to include additional text/content by
+ * form designers to provide additional information. It is not possible to submit any
+ * value(s) for it.
+ *
+ * @group Form.io components
+ * @category Concrete types
+ */
+export interface ContentSchema
+  extends Omit<
+      LayoutComponentSchema<never>,
+      | 'multiple'
+      | 'defaultValue'
+      | 'clearOnHide'
+      | 'validate'
+      | 'errors'
+      | 'description'
+      | 'hideLabel'
+      | 'disabled'
+      | 'widget'
+      | 'validateOn'
+      | 'placeholder'
+    >,
+    DisplayConfig,
+    OFExtensions {
+  id: string;
+  key: string;
+  type: 'content';
+  /**
+   * Even though the label is present, it is typically not displayed anywhere.
+   */
+  html: string;
+  label?: string;
+  hidden?: boolean;
+  customClass?: '' | 'success' | 'info' | 'warning' | 'error';
+}

--- a/src/formio/components/index.ts
+++ b/src/formio/components/index.ts
@@ -1,4 +1,8 @@
+// Input components
 export * from './textfield';
 export * from './email';
 export * from './date';
 export * from './number';
+
+// Layout components
+export * from './content';

--- a/test-d/formio/components/content.test-d.ts
+++ b/test-d/formio/components/content.test-d.ts
@@ -1,0 +1,56 @@
+import {expectAssignable, expectNotAssignable} from 'tsd';
+
+import {ContentSchema} from '../../../lib';
+
+// Minimal schema
+expectAssignable<ContentSchema>({
+  id: 'eqegfc',
+  type: 'content',
+  html: '',
+  key: 'content',
+});
+
+// Full schema
+expectAssignable<ContentSchema>({
+  id: 'eqegfc',
+  type: 'content',
+  // Display tab
+  html: 'inhoud',
+  label: 'Content',
+  key: 'content',
+  hidden: false,
+  showInEmail: false,
+  showInSummary: false,
+  showInPDF: true,
+  customClass: '',
+  // Advanced tab
+  conditional: {
+    show: undefined,
+    when: '',
+    eq: '',
+  },
+  // Translations
+  openForms: {
+    translations: {
+      nl: [],
+    },
+  },
+});
+
+// Bad customClass value
+expectNotAssignable<ContentSchema>({
+  id: 'eqegfc',
+  type: 'content',
+  html: '',
+  key: 'content',
+  customClass: 'arbitraryValue',
+});
+
+// Default value makes no sense for a layout component
+expectNotAssignable<ContentSchema>({
+  id: 'eqegfc',
+  type: 'content',
+  html: '',
+  key: 'content',
+  defaultValue: '',
+});


### PR DESCRIPTION
Relates to #2

This strips out most of the super-type schema properties, as they are not relevant for the content component.