### PR TITLE
:recycle: Refactor multiple type into interfaces

### DIFF
--- a/src/formio/base.ts
+++ b/src/formio/base.ts
@@ -16,6 +16,18 @@ export interface HasValidation<VN extends CuratedValidatorNames> {
   translatedErrors?: ErrorTranslations<ComponentErrorKeys<VN>>;
 }
 
+// any schema having (localised) validators
+export type SchemaWithValidation = HasValidation<CuratedValidatorNames>;
+// given a specific component schema, extract the possible keys that can be used for
+// translated/specific validation errors. This returns the translatable error keys, not
+// the validator names.
+export type PossibleValidatorErrorKeys<S extends SchemaWithValidation> = Exclude<
+  keyof Required<S>['errors'],
+  // MultiCapable causes objects to be part of the type, resulting in keyof Object
+  // also being a valid key, but it isn't.
+  keyof Object
+>;
+
 /**
  * @group Open Forms schema extensions
  */

--- a/src/formio/base.ts
+++ b/src/formio/base.ts
@@ -95,6 +95,16 @@ export interface StrictComponentSchema<T>
   label: string;
 }
 
+interface Multiple<T> {
+  multiple?: true;
+  defaultValue?: T[];
+}
+
+interface Single<T> {
+  multiple?: false;
+  defaultValue?: T;
+}
+
 /**
  * Make a given component schema multiple capable by type narrowing the `defaultValue`
  * based on the (literal) value of the multiple key.
@@ -108,8 +118,8 @@ export interface StrictComponentSchema<T>
  */
 export type MultipleCapable<S> = S extends StrictComponentSchema<infer T>
   ? T extends Array<infer NT>
-    ? S & {multiple?: true; defaultValue?: NT[]}
-    : S & {multiple?: false; defaultValue?: T}
+    ? S & Multiple<NT>
+    : S & Single<T>
   : never;
 
 // (user) inputs

--- a/test-d/formio/base.test-d.ts
+++ b/test-d/formio/base.test-d.ts
@@ -1,0 +1,16 @@
+import {expectAssignable, expectNotAssignable} from 'tsd';
+
+import {TextFieldComponentSchema} from '../../lib';
+import {PossibleValidatorErrorKeys} from '../../lib/formio/base';
+
+type ValidatorErrorKeys = PossibleValidatorErrorKeys<TextFieldComponentSchema>;
+
+expectAssignable<ValidatorErrorKeys>('required');
+expectAssignable<ValidatorErrorKeys>('maxLength');
+expectAssignable<ValidatorErrorKeys>('pattern');
+
+expectNotAssignable<ValidatorErrorKeys>('');
+expectNotAssignable<ValidatorErrorKeys>('foo');
+expectNotAssignable<ValidatorErrorKeys>('minLength');
+expectNotAssignable<ValidatorErrorKeys>('min');
+expectNotAssignable<ValidatorErrorKeys>('constructor');


### PR DESCRIPTION
Hopefully this works and it can avoid the derived `keyof Object` from composed types. I suspect this is because the intersection is treated as an object literal and not a interface.

(formio-builder gets complaints about `constructor` not being assignable to a literals union)