### PR TITLE
:bug: Add missing properties for file component

### DIFF
--- a/src/formio/components/file.ts
+++ b/src/formio/components/file.ts
@@ -82,8 +82,9 @@ export interface BaseFileComponentSchema
     HasValidation<Validator> {
   type: 'file';
   multiple?: boolean;
-
   // (possibly) more-constrained existing formio properties
+  webcam: false;
+  options: {withCredentials: true};
   storage: 'url';
   url: string;
   file: FileUploadConfiguration;

--- a/test-d/formio/components/file.test-d.ts
+++ b/test-d/formio/components/file.test-d.ts
@@ -26,6 +26,8 @@ expectAssignable<FileComponentSchema>({
   type: 'file',
   key: 'someFile',
   label: 'Attachment',
+  webcam: false,
+  options: {withCredentials: true},
   storage: 'url',
   url: '',
   file: {
@@ -43,6 +45,8 @@ const explicitSingleUpload: FileComponentSchema = {
   type: 'file',
   key: 'someFile',
   label: 'Attachment',
+  webcam: false,
+  options: {withCredentials: true},
   storage: 'url',
   url: '',
   file: {
@@ -63,6 +67,8 @@ const explicitMultipleUpload: FileComponentSchema = {
   type: 'file',
   key: 'someFile',
   label: 'Attachment',
+  webcam: false,
+  options: {withCredentials: true},
   storage: 'url',
   url: '',
   file: {
@@ -83,6 +89,8 @@ const implicitSingleUpload: FileComponentSchema = {
   type: 'file',
   key: 'someFile',
   label: 'Attachment',
+  webcam: false,
+  options: {withCredentials: true},
   storage: 'url',
   url: '',
   file: {
@@ -106,6 +114,8 @@ expectAssignable<FileComponentSchema>({
   key: 'someInput',
   label: 'Some input',
   // builder sets empty URL, backend dynamically makes this non-empty
+  webcam: false,
+  options: {withCredentials: true},
   storage: 'url',
   url: '',
   file: {
@@ -143,6 +153,8 @@ expectAssignable<FileComponentSchema>({
 expectAssignable<FileComponentSchema>({
   id: 'yejak',
   type: 'file',
+  webcam: false,
+  options: {withCredentials: true},
   storage: 'url',
   url: '',
   // basic tab in builder form
@@ -219,6 +231,8 @@ expectNotAssignable<FileComponentSchema>({
   type: 'content',
   key: 'someFile',
   label: 'Attachment',
+  webcam: false,
+  options: {withCredentials: true},
   storage: 'url',
   url: '',
   file: {
@@ -235,6 +249,8 @@ expectNotAssignable<FileComponentSchema>({
   type: 'file',
   key: 'someFile',
   label: 'Attachment',
+  webcam: false,
+  options: {withCredentials: true},
   storage: 's3', // we only support url
   url: '',
   file: {


### PR DESCRIPTION
* webcam: false is set in our default form builder configuration, and it affects the SDK/renderer in that no webcam integration needs to be built/enabled
* options object is set as string in our current builder, but it is then at run-time parsed as JSON. We can shortcut this and directly set it as an object. The withCredentials option is required for XHR uploads to send cookies. This will likely become obsolete when we replace the formio renderer with our own and have a fetch-based upload client.