### PR TITLE
🐛 `currency` is not multiple capable

### DIFF
--- a/src/formio/components/currency.ts
+++ b/src/formio/components/currency.ts
@@ -1,4 +1,4 @@
-import {InputComponentSchema, MultipleCapable} from '..';
+import {InputComponentSchema} from '..';
 
 type Validator = 'required' | 'min' | 'max';
 type TranslatableKeys = 'label' | 'description' | 'tooltip';
@@ -7,18 +7,13 @@ export type CurrencyInputSchema = InputComponentSchema<number, Validator, Transl
 
 /**
  * @group Form.io components
- * @category Base types
+ * @category Concrete types
  */
-export interface BaseCurrencyComponentSchema extends Omit<CurrencyInputSchema, 'hideLabel'> {
+export interface CurrencyComponentSchema extends Omit<CurrencyInputSchema, 'hideLabel'> {
   type: 'currency';
   // additional properties
   currency: 'EUR';
   decimalLimit?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10;
   allowNegative?: boolean;
+  defaultValue?: number;
 }
-
-/**
- * @group Form.io components
- * @category Concrete types
- */
-export type CurrencyComponentSchema = MultipleCapable<BaseCurrencyComponentSchema>;

--- a/test-d/formio/components/currency.test-d.ts
+++ b/test-d/formio/components/currency.test-d.ts
@@ -56,16 +56,6 @@ expectNotAssignable<CurrencyComponentSchema>({
   hideLabel: true,
 } as const);
 
-expectAssignable<CurrencyComponentSchema>({
-  id: '123',
-  type: 'currency',
-  key: 'aCurrency',
-  label: 'A currency',
-  currency: 'EUR',
-  multiple: true,
-  defaultValue: [],
-});
-
 // invalid, only the number validators may be assignable
 expectNotAssignable<CurrencyComponentSchema>({
   id: '123',
@@ -134,7 +124,7 @@ expectAssignable<CurrencyComponentSchema>({
   },
 });
 
-// invalid, multiple true and non-array default value
+// invalid, multiple true
 expectNotAssignable<CurrencyComponentSchema>({
   id: '123',
   type: 'currency',
@@ -142,7 +132,6 @@ expectNotAssignable<CurrencyComponentSchema>({
   label: 'A currency',
   currency: 'EUR',
   multiple: true,
-  defaultValue: 2,
 });
 
 // invalid, multiple false and array default value
@@ -154,15 +143,4 @@ expectNotAssignable<CurrencyComponentSchema>({
   currency: 'EUR',
   multiple: false,
   defaultValue: [1],
-});
-
-// invalid, multiple true and wrong default value in array element
-expectNotAssignable<CurrencyComponentSchema>({
-  id: '123',
-  type: 'currency',
-  key: 'aCurrency',
-  label: 'A currency',
-  currency: 'EUR',
-  multiple: true,
-  defaultValue: ['a string and not a number'],
 });


### PR DESCRIPTION
As discussed: https://github.com/open-formulieren/formio-builder/pull/50#discussion_r1386162318