### PR TITLE
:fire: Blacklist 'widget' property

### DIFF
--- a/src/formio/base.ts
+++ b/src/formio/base.ts
@@ -85,6 +85,7 @@ type UnusedFormioProperties =
   | 'customDefaultValue'
   | 'calculateValue'
   | 'allowCalculateOverride'
+  | 'widget'
   | 'refreshOn'
   | 'clearOnRefresh'
   // we roll our own validate with only the relevant keys for each component


### PR DESCRIPTION
We don't use it an it's typed as any anyway, so it's not very useful.