### PR TITLE
:sparkles: Add the types for the Flatpickr custom options for the widget

### DIFF
--- a/src/formio/components/date.ts
+++ b/src/formio/components/date.ts
@@ -5,6 +5,7 @@ import {
   PastDateConstraint as BasePastDateConstraint,
   DateConstraintConfiguration,
   DatePickerConfig,
+  PickerCustomOptions,
 } from '../dates';
 
 type Validator = 'required';
@@ -33,6 +34,7 @@ export interface BaseDateComponentSchema extends Omit<DateInputSchema, 'hideLabe
     maxDate?: Exclude<DateConstraintConfiguration, FutureOrPastDateConstraint> | PastDateConstraint;
   };
   datePicker?: DatePickerConfig;
+  customOptions?: PickerCustomOptions;
 }
 
 /**

--- a/src/formio/components/datetime.ts
+++ b/src/formio/components/datetime.ts
@@ -5,6 +5,7 @@ import {
   DatePickerConfig,
   FutureDateConstraint,
   PastDateConstraint,
+  PickerCustomOptions,
 } from '../dates';
 
 type Validator = 'required';
@@ -25,6 +26,7 @@ export interface BaseDateTimeComponentSchema
     maxDate?: Exclude<DateConstraintConfiguration, FutureDateConstraint>;
   };
   datePicker?: DatePickerConfig;
+  customOptions?: PickerCustomOptions;
 }
 
 /**

--- a/src/formio/dates.ts
+++ b/src/formio/dates.ts
@@ -83,3 +83,8 @@ export interface DatePickerConfig {
   minDate: string | null;
   maxDate: string | null;
 }
+
+/** Flatpickr specific custom options for the widget **/
+export interface PickerCustomOptions {
+  allowInvalidPreload?: boolean;
+}

--- a/test-d/formio/components/date.test-d.ts
+++ b/test-d/formio/components/date.test-d.ts
@@ -134,6 +134,9 @@ expectAssignable<DateComponentSchema>({
       },
     },
   },
+  customOptions: {
+    allowInvalidPreload: true,
+  },
 });
 
 // invalid, multiple true and non-array default value

--- a/test-d/formio/components/datetime.test-d.ts
+++ b/test-d/formio/components/datetime.test-d.ts
@@ -134,6 +134,9 @@ expectAssignable<DateTimeComponentSchema>({
       },
     },
   },
+  customOptions: {
+    allowInvalidPreload: true,
+  },
 });
 
 // invalid, multiple true and non-array default value


### PR DESCRIPTION
Fixes https://github.com/open-formulieren/open-forms/issues/3755

Related to https://github.com/open-formulieren/open-forms/issues/3755 where the widget needs to have a configuration option set so that invalid values are not automatically removed from the widget