### PR TITLE
Disallow null values for prefill plugin or attribute

### DIFF
--- a/src/formio/base.ts
+++ b/src/formio/base.ts
@@ -42,8 +42,8 @@ export interface DisplayConfig {
  */
 export interface PrefillConfig {
   prefill?: {
-    plugin: string | null;
-    attribute: string | null;
+    plugin: string; // when no prefill is applicable, the value must be empty string
+    attribute: string; // when no prefill is applicable, the value must be empty string
     identifierRole: 'main' | 'authorised_person';
   };
 }


### PR DESCRIPTION
Partly closes open-formulieren/open-forms#3922

null values are okay-ish in the Javascript code, but cause constraint errors when the component is used to populate a FormVariable in the backend which does not allow NULL values.