### PR TITLE
Remove support for defaultValue translations

### DIFF
--- a/src/formio/components/textarea.ts
+++ b/src/formio/components/textarea.ts
@@ -1,7 +1,7 @@
 import {InputComponentSchema, MultipleCapable} from '..';
 
 type Validator = 'required' | 'maxLength' | 'pattern';
-type TranslatableKeys = 'label' | 'description' | 'tooltip' | 'defaultValue' | 'placeholder';
+type TranslatableKeys = 'label' | 'description' | 'tooltip' | 'placeholder';
 
 export type TextareaInputSchema = InputComponentSchema<string, Validator, TranslatableKeys>;
 

--- a/src/formio/components/textfield.ts
+++ b/src/formio/components/textfield.ts
@@ -1,7 +1,7 @@
 import {InputComponentSchema, MultipleCapable, PrefillConfig} from '..';
 
 type Validator = 'required' | 'maxLength' | 'pattern';
-type TranslatableKeys = 'label' | 'description' | 'tooltip' | 'defaultValue' | 'placeholder';
+type TranslatableKeys = 'label' | 'description' | 'tooltip' | 'placeholder';
 
 export type TextFieldInputSchema = InputComponentSchema<string, Validator, TranslatableKeys>;
 


### PR DESCRIPTION
Partly closes open-formulieren/open-forms#4362

It is unused and too complex with 'multiple: true' cases, causing crashes in the admin interface.