### PR TITLE
[OF#4423] Add layout property to addressnl

### DIFF
--- a/src/formio/components/addressNL.ts
+++ b/src/formio/components/addressNL.ts
@@ -23,4 +23,5 @@ export interface AddressNLComponentSchema
   extends Omit<AddressNLInputSchema, 'hideLabel' | 'placeholder' | 'disabled' | 'validateOn'> {
   type: 'addressNL';
   deriveAddress: boolean;
+  layout: 'singleColumn' | 'doubleColumn';
 }

--- a/test-d/formio/components/addressNL.test-d.ts
+++ b/test-d/formio/components/addressNL.test-d.ts
@@ -9,6 +9,7 @@ expectAssignable<AddressNLComponentSchema>({
   key: 'someAddressNL',
   label: 'Some AddressNL',
   deriveAddress: false,
+  layout: 'doubleColumn',
 });
 
 // appropriate default value type
@@ -18,6 +19,7 @@ expectAssignable<AddressNLComponentSchema>({
   key: 'someAddressNL',
   label: 'Some AddressNL',
   deriveAddress: false,
+  layout: 'doubleColumn',
   defaultValue: {
     postcode: '',
     houseNumber: '',
@@ -45,6 +47,7 @@ expectAssignable<AddressNLComponentSchema>({
   clearOnHide: true,
   isSensitiveData: true,
   deriveAddress: false,
+  layout: 'doubleColumn',
   // Advanced tab
   conditional: {
     show: undefined,
@@ -82,4 +85,5 @@ expectNotAssignable<AddressNLComponentSchema>({
   placeholder: '',
   hideLabel: true,
   deriveAddress: false,
+  layout: 'doubleColumn',
 } as const);


### PR DESCRIPTION
Partly fixes https://github.com/open-formulieren/open-forms/issues/4423

`layout` property was added in order to be able to choose between `singleColumn` or `doubleColumn` for the rendering of the `addressNL` component