### PR TITLE
[maykinmedia/open-producten#24] remove product attribute from Product

### DIFF
--- a/src/formio/components/productPrice.ts
+++ b/src/formio/components/productPrice.ts
@@ -14,5 +14,4 @@ export type ProductPriceInputSchema = InputComponentSchema<never, Validator, Tra
 export interface ProductPriceComponentSchema
   extends Omit<ProductPriceInputSchema, 'hideLabel' | 'disabled'> {
   type: 'productPrice';
-  product: string;
 }

--- a/test-d/formio/components/productPrice.test-d.ts
+++ b/test-d/formio/components/productPrice.test-d.ts
@@ -8,7 +8,6 @@ expectAssignable<ProductPriceComponentSchema>({
   type: 'productPrice',
   key: 'aProductPrice',
   label: 'A Product Price',
-  product: '123'
 } as const);
 
 // different component type
@@ -22,7 +21,6 @@ expectNotAssignable<ProductPriceComponentSchema>({
   type: 'productPrice',
   key: 'aProductPrice',
   label: 'A Product Price',
-  product: '123',
   hideLabel: true,
 } as const);
 
@@ -32,7 +30,6 @@ expectNotAssignable<ProductPriceComponentSchema>({
   type: 'productPrice',
   key: 'aProductPrice',
   label: 'A Product Price',
-  product: '123',
   defaultValue: 1,
 });
 
@@ -43,7 +40,6 @@ expectAssignable<ProductPriceComponentSchema>({
   // basic tab in builder form
   key: 'aProductPrice',
   label: 'A Product Price',
-  product: '123',
   description: 'Sample description',
   tooltip: 'A tooltip',
   showInSummary: true,


### PR DESCRIPTION
Removes the product attribute as it will be set on the form instead of in the component.