### PR TITLE
Adding PrefillConfig to BaseNumberComponentSchema

### DIFF
--- a/src/formio/components/number.ts
+++ b/src/formio/components/number.ts
@@ -1,4 +1,4 @@
-import {InputComponentSchema} from '..';
+import {InputComponentSchema, PrefillConfig} from '..';
 
 type Validator = 'required' | 'min' | 'max';
 type TranslatableKeys = 'label' | 'description' | 'tooltip' | 'suffix';
@@ -10,7 +10,8 @@ export type NumberInputSchema = InputComponentSchema<number | null, Validator, T
  * @category Base types
  */
 export interface BaseNumberComponentSchema
-  extends Omit<NumberInputSchema, 'hideLabel' | 'placeholder'> {
+  extends Omit<NumberInputSchema, 'hideLabel' | 'placeholder'>,
+    PrefillConfig {
   type: 'number';
   defaultValue?: number | null;
   /*


### PR DESCRIPTION
Partly solves open-formulieren/open-forms#4813

Added the prefillConfig to the number component allows prefill configuration on number fields