### PR TITLE
Updated MapComponentSchema for kaartmateriaal background feature

### DIFF
--- a/src/formio/components/map.ts
+++ b/src/formio/components/map.ts
@@ -42,6 +42,10 @@ export interface MapComponentSchema
     lng?: number;
   };
   /**
+   * The tile layer identifier used for the map component tile layer.
+   */
+  tileLayerIdentifier?: string;
+  /**
    * If true, the backend must apply the globally configured defaults to a particular
    * map instance. This results in populating `defaultZoom` and `initialCenter`, so for
    * the SDK this property has no effect.


### PR DESCRIPTION
Part of open-formulieren/open-forms#2173

Updated the MapComponentSchema for the kaartmateriaal background changes.

Added `backgroundIdentifier` as property to MapComponentSchema