### PR TITLE
Added property for automatic calculated tile layer url

### DIFF
--- a/src/formio/components/map.ts
+++ b/src/formio/components/map.ts
@@ -46,6 +46,15 @@ export interface MapComponentSchema
    */
   tileLayerIdentifier?: string;
   /**
+   * The url belonging to the connected tile layer object, determined by
+   * tileLayerIdentifier.
+   *
+   * This value should not be definable by admins, but should be fetched
+   * from the related tile layer object. This happens when fetching the
+   * component from the backend.
+   */
+  tileLayerUrl?: string;
+  /**
    * If true, the backend must apply the globally configured defaults to a particular
    * map instance. This results in populating `defaultZoom` and `initialCenter`, so for
    * the SDK this property has no effect.


### PR DESCRIPTION
The url for the tile layer is determined when fetching the component data from the backend. This is done using the `rewrite_for_request` step. This ensures that the tile layer object can be updated, and that all components using this tile layer are changed accordingly.

Adding this type to make sure that we are type save (and possibly able to make the future step towards typescript), and that we know which values to expect