### PR TITLE
Add interaction property to component

### DIFF
--- a/src/formio/components/map.ts
+++ b/src/formio/components/map.ts
@@ -55,6 +55,18 @@ export interface MapComponentSchema
    */
   tileLayerUrl?: string;
   /**
+   * Interactions users can use when working with the map component.
+   *
+   * These interaction options are based on the options available in leaflet draw:
+   * https://leaflet.github.io/Leaflet.draw/docs/leaflet-draw-latest.html#drawoptions
+   */
+  interactions?: {
+    circle: boolean;
+    polygon: boolean;
+    polyline: boolean;
+    marker: boolean;
+  };
+  /**
    * If true, the backend must apply the globally configured defaults to a particular
    * map instance. This results in populating `defaultZoom` and `initialCenter`, so for
    * the SDK this property has no effect.


### PR DESCRIPTION
Part of open-formulieren/open-forms#2177

The interactions are base on the leaflet draw options: https://leaflet.github.io/Leaflet.draw/docs/leaflet-draw-latest.html#drawoptions.
Leaflet offers two more options: rectangle and circlemarker. Both seem not very useful (circlemarker being a weird mix of marker and circle, with less precision and flexibility, and rectangle just being weird..)