### PR TITLE
Removing circle from the available map interactions

### DIFF
--- a/src/formio/components/map.ts
+++ b/src/formio/components/map.ts
@@ -61,7 +61,6 @@ export interface MapComponentSchema
    * https://leaflet.github.io/Leaflet.draw/docs/leaflet-draw-latest.html#drawoptions
    */
   interactions?: {
-    circle: boolean;
     polygon: boolean;
     polyline: boolean;
     marker: boolean;


### PR DESCRIPTION
This should not have been added in the first place..

Circle interaction is a leaflet custom thing, that isn't supported by geoJson. (To make it work, we would have to define some custom properties to differentiate between a simple marker and a circle). Due to this reason, the registration apis don't/probably won't support this interaction.

Perhaps when GeoJson supports circles, we can add this. But until that point, this shouldn't be used..