### PR TITLE
:sparkles: [open-formulieren/open-forms#5073] transformData attribute for selectboxes

### DIFF
--- a/src/formio/components/selectboxes.ts
+++ b/src/formio/components/selectboxes.ts
@@ -21,6 +21,7 @@ export type SelectboxesUnsupported = 'hideLabel' | 'disabled';
 interface BaseSelectboxesSchema {
   type: 'selectboxes';
   defaultValue: Record<string, boolean>;
+  openForms?: {transformData?: boolean};
 }
 
 /**

--- a/test-d/formio/components/selectboxes.test-d.ts
+++ b/test-d/formio/components/selectboxes.test-d.ts
@@ -12,6 +12,7 @@ expectAssignable<SelectboxesComponentSchema>({
   openForms: {
     dataSrc: 'manual',
     translations: {},
+    transformData: false,
   },
   values: [
     {
@@ -32,6 +33,7 @@ expectAssignable<SelectboxesComponentSchema>({
     dataSrc: 'variable',
     itemsExpression: 'dummy',
     translations: {},
+    transformData: false,
   },
 });
 
@@ -45,6 +47,7 @@ expectAssignable<SelectboxesComponentSchema>({
   openForms: {
     dataSrc: 'manual',
     translations: {},
+    transformData: false,
   },
   values: [
     {
@@ -106,6 +109,7 @@ expectAssignable<SelectboxesComponentSchema>({
     },
     dataSrc: 'variable',
     itemsExpression: 'dummy',
+    transformData: false,
   },
   // fixed but not editable
   validateOn: 'blur',


### PR DESCRIPTION
closes open-formulieren/open-forms#5073 partially