### PR TITLE
Correctly type the conditional.eq property

### DIFF
--- a/src/formio/base.ts
+++ b/src/formio/base.ts
@@ -1,4 +1,4 @@
-import {ComponentSchema} from 'formiojs';
+import {ComponentSchema as FormioComponentSchema} from 'formiojs';
 
 import {ComponentTranslations, ErrorTranslations} from './i18n';
 import {
@@ -59,6 +59,35 @@ export type PossibleValidatorErrorKeys<S extends SchemaWithValidation> = Exclude
   // also being a valid key, but it isn't.
   keyof Object
 >;
+
+/**
+ * Replacement of Formio's `ConditionalOptions`, changes are:
+ *
+ * - we don't support `json`
+ * - `eq` can be any JSON-serializable type, not just string. Note that our builder
+ *   uses appropriate JS types for the component type referenced via `when`.`
+ */
+export interface OFConditionalOptions {
+  /** If the field should show if the condition is true */
+  show?: boolean;
+  /** The field API key that it should compare its value against to determine if the condition is triggered. */
+  when?: string;
+  /**
+   * The value that should be checked against the comparison component.
+   *
+   * For array values, the array is checked if it contains the specified value.
+   *
+   * @note Only (a subset of) primitives are supported.
+   */
+  eq?: string | number | boolean;
+}
+
+interface ComponentSchema<T = any> extends Omit<FormioComponentSchema<T>, 'conditional'> {
+  /**
+   * Dynamically determines if the component is visible/available.
+   */
+  conditional?: OFConditionalOptions;
+}
 
 /**
  * @group Open Forms schema extensions


### PR DESCRIPTION
Formio (correctly) types this as a string for how their own SDK works, which is by treating everything as a string and casting non-string values to a string before comparing it to component.conditional.eq.

However, our own builder and backend actually require the correct JSON types, e.g. a number component comparison has a number type for eq while a checkbox component reference has a boolean type. We widen the type here to match the behaviour of the builder and make it possible to implement strong typed behaviour in our own renderer.

We achieve this by removing and re-adding the property from the reference type of the Formio SDK, since extending/inheriting is not allowed (you can only narrow types that way).