### PR TITLE
Remove prefill config from customer interaction component

### DIFF
--- a/src/formio/components/customerInteraction.ts
+++ b/src/formio/components/customerInteraction.ts
@@ -1,9 +1,9 @@
-import {InputComponentSchema, PrefillConfig} from '..';
+import {InputComponentSchema} from '..';
 
 type Validator = 'required';
 type TranslatableKeys = 'label' | 'description' | 'tooltip';
 
-interface DigitalAddress {
+export interface DigitalAddress {
   address: string;
   useOnlyOnce?: boolean;
   isNewPreferred?: boolean;
@@ -41,5 +41,4 @@ export type CustomerInteractionComponentSchema = Omit<
   CustomerInteractionInputSchema,
   'hideLabel' | 'placeholder' | 'disabled' | 'validateOn'
 > &
-  CustomerInteractionProperties &
-  PrefillConfig;
+  CustomerInteractionProperties;


### PR DESCRIPTION
Partly closes open-formulieren/open-forms#5708

The prefill for this component will be done through a user variable. Because the prefill data cannot be directly set on the component default value. The prefill data needs proper and custom handling.