### PR TITLE
Loosely-coupled digital address types on customerProfile

### DIFF
--- a/src/formio/components/customerProfile.ts
+++ b/src/formio/components/customerProfile.ts
@@ -3,16 +3,16 @@ import {InputComponentSchema} from '..';
 type Validator = 'required';
 type TranslatableKeys = 'label' | 'description' | 'tooltip';
 
-export interface DigitalAddress {
+export type DigitalAddressType = 'email' | 'phoneNumber';
+
+export type DigitalAddress = {
   address: string;
+  type: DigitalAddressType;
   useOnlyOnce?: boolean;
   isNewPreferred?: boolean;
-}
+};
 
-export interface CustomerProfileData {
-  email?: DigitalAddress;
-  phoneNumber?: DigitalAddress;
-}
+export type CustomerProfileData = DigitalAddress[];
 
 export type CustomerProfileInputSchema = InputComponentSchema<
   CustomerProfileData,
@@ -27,10 +27,7 @@ export type CustomerProfileInputSchema = InputComponentSchema<
 export interface CustomerProfileProperties {
   type: 'customerProfile';
   shouldUpdateCustomerData: boolean;
-  digitalAddressTypes: {
-    email: boolean;
-    phoneNumber: boolean;
-  };
+  digitalAddressTypes: DigitalAddressType[];
 }
 
 /**

--- a/test-d/formio/components/customerProfile.test-d.ts
+++ b/test-d/formio/components/customerProfile.test-d.ts
@@ -8,10 +8,7 @@ expectAssignable<CustomerProfileComponentSchema>({
   type: 'customerProfile',
   key: 'customerProfile',
   label: 'Customer profile',
-  digitalAddressTypes: {
-    email: true,
-    phoneNumber: true,
-  },
+  digitalAddressTypes: ['email', 'phoneNumber'],
   shouldUpdateCustomerData: false,
 });
 
@@ -23,10 +20,7 @@ expectAssignable<CustomerProfileComponentSchema>({
   label: 'Customer profile',
   description: 'Customer profile description',
   tooltip: 'Customer profile tooltip',
-  digitalAddressTypes: {
-    email: true,
-    phoneNumber: true,
-  },
+  digitalAddressTypes: ['email', 'phoneNumber'],
   shouldUpdateCustomerData: false,
 });
 
@@ -36,10 +30,7 @@ expectAssignable<CustomerProfileComponentSchema>({
   type: 'customerProfile',
   key: 'customerProfile',
   label: 'Customer profile',
-  digitalAddressTypes: {
-    email: true,
-    phoneNumber: true,
-  },
+  digitalAddressTypes: ['email', 'phoneNumber'],
   shouldUpdateCustomerData: false,
   openForms: {
     translations: {


### PR DESCRIPTION
Partly closes https://github.com/open-formulieren/open-forms/issues/5708

Adopting a more loosely coupled setup for the customerProfile component, to allow future expending of the available digital address types.

Instead of expecting the component to contain `email` and `phoneNumber` digital address types, we now allow any type of digital address that is defined in `DigitalAddressType`.
The allowed digital addresses are now also defined as a list of digital address types, instead of the hard defined digital address types object.