### PR TITLE
Support better mechanism to specify document type in file component registration

### DIFF
--- a/src/components/file.ts
+++ b/src/components/file.ts
@@ -159,10 +159,34 @@ interface FileExtras {
    * configurations/options at the form level.
    */
   registration?: {
-    informatieobjecttype?: string;
     bronorganisatie?: string;
     docVertrouwelijkheidaanduiding?: string;
     titel?: string;
+
+    /**
+     * Configuration to resolve the document type to use. Replaces the
+     * `informatieobjecttype` fixed URL reference.
+     *
+     * See the `ZaakOptionsSerializer` serializer in the backend for prior art and usage.
+     */
+    documentType?: {
+      catalogue: {
+        domain: string;
+        rsin: string;
+      };
+      /**
+       * Description of the document type to use. The backend will resolve it at runtime
+       * and automatically select the appropriate version. It is looked up within the
+       * specified catalogue.
+       */
+      description: string;
+    };
+    /**
+     * URL reference to the informatieobjecttype in the Catalogi API.
+     *
+     * @deprecated Deprecated in favour of the catalogue + description references.
+     */
+    informatieobjecttype?: string;
   };
 }
 

--- a/test-d/formio/components/file.test-d.ts
+++ b/test-d/formio/components/file.test-d.ts
@@ -113,10 +113,17 @@ expectAssignable<FileComponentSchema>({
   maxNumberOfFiles: 3, // custom setting
   // registration tab in builder form
   registration: {
-    informatieobjecttype: '',
     bronorganisatie: '',
     docVertrouwelijkheidaanduiding: 'openbaar',
     titel: '',
+    informatieobjecttype: '',
+    documentType: {
+      catalogue: {
+        rsin: '000000000',
+        domain: 'VTH',
+      },
+      description: 'Attachment',
+    },
   },
   // (mostly) translations tab in builder form
   openForms: {


### PR DESCRIPTION
Part of open-formulieren/open-forms#283

Similar to the backend configuration for ZGW APIs and Object APIs, at the component level we can support the documenttype reference by pointing to a catalogue (by its identifying properties) and description of documenttype. Catalogue + description and date uniquely resolve (a version of) a document type in the Catalogi API.