### PR TITLE
[#6315] add FAQItems option to component schemas

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -6,6 +6,7 @@
  *
  * @module common
  */
+import {SupportedLocales} from './i18n';
 
 export type Label = {
   /**
@@ -27,6 +28,33 @@ export type Tooltip = {
    * with the tooltip icon/control near the label.
    */
   tooltip?: string;
+};
+
+export type FAQItem = {
+  /**
+   * Short interactive label. Interacting will result in the content being displayed.
+   */
+  label: string;
+  /**
+   * Rich text content, displayed in a modal after interacting with the label.
+   */
+  content: string;
+  openforms?: {
+    /**
+     * Translations for the user-facing texts. The backend processes this and assigns
+     * the matching top-level properties.
+     */
+    translations: {
+      [K in SupportedLocales]?: {
+        label?: string;
+        content?: string;
+      };
+    };
+  };
+};
+
+export type FAQItems = {
+  faqItems?: FAQItem[];
 };
 
 export type Hidden = {

--- a/src/components/addressNL.ts
+++ b/src/components/addressNL.ts
@@ -1,5 +1,13 @@
 import {BaseComponent, Prettify} from '../base';
-import {ClearOnHide, Description, Hidden, IsSensitiveData, Label, Tooltip} from '../common';
+import {
+  ClearOnHide,
+  Description,
+  FAQItems,
+  Hidden,
+  IsSensitiveData,
+  Label,
+  Tooltip,
+} from '../common';
 import {Conditional, DisplayConfig, OFExtensions, Registration} from '../extensions';
 import {Validation} from '../validation';
 
@@ -78,6 +86,7 @@ export type AddressNLComponentSchema = Prettify<
     Label &
     Description &
     Tooltip &
+    FAQItems &
     DisplayConfig &
     Hidden &
     ClearOnHide &

--- a/src/components/bsn.ts
+++ b/src/components/bsn.ts
@@ -2,6 +2,7 @@ import {BaseComponent, Prettify, WithMultiple} from '../base';
 import {
   ClearOnHide,
   Description,
+  FAQItems,
   Hidden,
   IsSensitiveData,
   Label,
@@ -26,6 +27,7 @@ export type BsnComponentSchema = Prettify<
     Label &
     Description &
     Tooltip &
+    FAQItems &
     DisplayConfig &
     Hidden &
     ClearOnHide &

--- a/src/components/checkbox.ts
+++ b/src/components/checkbox.ts
@@ -3,6 +3,7 @@ import {
   ClearOnHide,
   DefaultValue,
   Description,
+  FAQItems,
   Hidden,
   IsSensitiveData,
   Label,
@@ -26,6 +27,7 @@ export type CheckboxComponentSchema = Prettify<
     Label &
     Description &
     Tooltip &
+    FAQItems &
     DisplayConfig &
     Hidden &
     ClearOnHide &

--- a/src/components/children.ts
+++ b/src/components/children.ts
@@ -1,5 +1,13 @@
 import {BaseComponent, Prettify} from '../base';
-import {ClearOnHide, Description, Hidden, IsSensitiveData, Label, Tooltip} from '../common';
+import {
+  ClearOnHide,
+  Description,
+  FAQItems,
+  Hidden,
+  IsSensitiveData,
+  Label,
+  Tooltip,
+} from '../common';
 import {Conditional, OFExtensions, Registration} from '../extensions';
 
 export interface ChildDetails {
@@ -31,6 +39,7 @@ export type ChildrenComponentSchema = Prettify<
     Label &
     Description &
     Tooltip &
+    FAQItems &
     Hidden &
     ClearOnHide &
     IsSensitiveData & {

--- a/src/components/cosign.ts
+++ b/src/components/cosign.ts
@@ -4,6 +4,7 @@ import {
   ClearOnHide,
   DefaultValue,
   Description,
+  FAQItems,
   Hidden,
   IsSensitiveData,
   Label,
@@ -51,6 +52,7 @@ export type CosignV2ComponentSchema = Prettify<
     Label &
     Description &
     Tooltip &
+    FAQItems &
     DisplayConfig &
     Hidden &
     ClearOnHide &

--- a/src/components/currency.ts
+++ b/src/components/currency.ts
@@ -3,6 +3,7 @@ import {
   ClearOnHide,
   DefaultValue,
   Description,
+  FAQItems,
   Hidden,
   IsSensitiveData,
   Label,
@@ -45,6 +46,7 @@ export type CurrencyComponentSchema = Prettify<
     Label &
     Description &
     Tooltip &
+    FAQItems &
     DisplayConfig &
     Hidden &
     ClearOnHide &

--- a/src/components/customerProfile.ts
+++ b/src/components/customerProfile.ts
@@ -1,5 +1,13 @@
 import {BaseComponent, Prettify} from '../base';
-import {ClearOnHide, Description, Hidden, IsSensitiveData, Label, Tooltip} from '../common';
+import {
+  ClearOnHide,
+  Description,
+  FAQItems,
+  Hidden,
+  IsSensitiveData,
+  Label,
+  Tooltip,
+} from '../common';
 import {Conditional, DisplayConfig, OFExtensions} from '../extensions';
 import {Validation} from '../validation';
 
@@ -72,6 +80,7 @@ export type CustomerProfileComponentSchema = Prettify<
     Label &
     Description &
     Tooltip &
+    FAQItems &
     DisplayConfig &
     CustomerProfileExtra &
     Hidden &

--- a/src/components/date.ts
+++ b/src/components/date.ts
@@ -2,6 +2,7 @@ import {BaseComponent, Prettify, WithMultiple} from '../base';
 import {
   ClearOnHide,
   Description,
+  FAQItems,
   Hidden,
   IsSensitiveData,
   Label,
@@ -107,6 +108,7 @@ export type DateComponentSchema = Prettify<
     Label &
     Description &
     Tooltip &
+    FAQItems &
     DisplayConfig &
     Hidden &
     ClearOnHide &

--- a/src/components/datetime.ts
+++ b/src/components/datetime.ts
@@ -2,6 +2,7 @@ import {BaseComponent, Prettify, WithMultiple} from '../base';
 import {
   ClearOnHide,
   Description,
+  FAQItems,
   Hidden,
   IsSensitiveData,
   Label,
@@ -104,6 +105,7 @@ export type DateTimeComponentSchema = Prettify<
     Label &
     Description &
     Tooltip &
+    FAQItems &
     DisplayConfig &
     Hidden &
     ClearOnHide &

--- a/src/components/editgrid.ts
+++ b/src/components/editgrid.ts
@@ -3,6 +3,7 @@ import {
   ClearOnHide,
   DefaultValue,
   Description,
+  FAQItems,
   Hidden,
   IsSensitiveData,
   Label,
@@ -67,6 +68,7 @@ export type EditGridComponentSchema = Prettify<
     Label &
     Description &
     Tooltip &
+    FAQItems &
     Hidden &
     // TODO: see if we can drop the `null`
     DefaultValue<unknown[] | null> &

--- a/src/components/email.ts
+++ b/src/components/email.ts
@@ -3,6 +3,7 @@ import {
   AutoComplete,
   ClearOnHide,
   Description,
+  FAQItems,
   Hidden,
   IsSensitiveData,
   Label,
@@ -34,6 +35,7 @@ export type EmailComponentSchema = Prettify<
     Label &
     Description &
     Tooltip &
+    FAQItems &
     DisplayConfig &
     Hidden &
     ClearOnHide &

--- a/src/components/fieldset.ts
+++ b/src/components/fieldset.ts
@@ -1,5 +1,5 @@
 import {BaseComponent, Prettify} from '../base';
-import {ClearOnHide, Hidden, Label, Tooltip} from '../common';
+import {ClearOnHide, FAQItems, Hidden, Label, Tooltip} from '../common';
 import {Conditional, OFExtensions} from '../extensions';
 import {AnyComponentSchema} from './index';
 
@@ -17,6 +17,7 @@ export type FieldsetComponentSchema = Prettify<
   BaseComponent<'fieldset'> &
     Label &
     Tooltip &
+    FAQItems &
     Hidden &
     ClearOnHide &
     Conditional &

--- a/src/components/file.ts
+++ b/src/components/file.ts
@@ -1,5 +1,13 @@
 import {BaseComponent, Prettify} from '../base';
-import {ClearOnHide, Description, Hidden, IsSensitiveData, Label, Tooltip} from '../common';
+import {
+  ClearOnHide,
+  Description,
+  FAQItems,
+  Hidden,
+  IsSensitiveData,
+  Label,
+  Tooltip,
+} from '../common';
 import {Conditional, DisplayConfig, OFExtensions} from '../extensions';
 import {Validation} from '../validation';
 
@@ -220,6 +228,7 @@ export type FileComponentSchema = Prettify<
     Label &
     Description &
     Tooltip &
+    FAQItems &
     DisplayConfig &
     Hidden &
     ClearOnHide &

--- a/src/components/iban.ts
+++ b/src/components/iban.ts
@@ -1,5 +1,13 @@
 import {BaseComponent, Prettify, WithMultiple} from '../base';
-import {ClearOnHide, Description, Hidden, IsSensitiveData, Label, Tooltip} from '../common';
+import {
+  ClearOnHide,
+  Description,
+  FAQItems,
+  Hidden,
+  IsSensitiveData,
+  Label,
+  Tooltip,
+} from '../common';
 import {Conditional, DisplayConfig, OFExtensions, Registration} from '../extensions';
 import {Validation} from '../validation';
 
@@ -18,6 +26,7 @@ export type IbanComponentSchema = Prettify<
     Label &
     Description &
     Tooltip &
+    FAQItems &
     DisplayConfig &
     Hidden &
     ClearOnHide &

--- a/src/components/licensePlate.ts
+++ b/src/components/licensePlate.ts
@@ -1,5 +1,13 @@
 import {BaseComponent, Prettify, WithMultiple} from '../base';
-import {ClearOnHide, Description, Hidden, IsSensitiveData, Label, Tooltip} from '../common';
+import {
+  ClearOnHide,
+  Description,
+  FAQItems,
+  Hidden,
+  IsSensitiveData,
+  Label,
+  Tooltip,
+} from '../common';
 import {Conditional, DisplayConfig, OFExtensions, Registration} from '../extensions';
 import {Validation} from '../validation';
 
@@ -18,6 +26,7 @@ export type LicensePlateComponentSchema = Prettify<
     Label &
     Description &
     Tooltip &
+    FAQItems &
     DisplayConfig &
     Hidden &
     ClearOnHide &

--- a/src/components/map.ts
+++ b/src/components/map.ts
@@ -1,5 +1,13 @@
 import {BaseComponent, Prettify} from '../base';
-import {ClearOnHide, Description, Hidden, IsSensitiveData, Label, Tooltip} from '../common';
+import {
+  ClearOnHide,
+  Description,
+  FAQItems,
+  Hidden,
+  IsSensitiveData,
+  Label,
+  Tooltip,
+} from '../common';
 import {Conditional, DisplayConfig, OFExtensions, Registration} from '../extensions';
 import {Validation} from '../validation';
 
@@ -180,6 +188,7 @@ export type MapComponentSchema = Prettify<
     Label &
     Description &
     Tooltip &
+    FAQItems &
     DisplayConfig &
     Hidden &
     ClearOnHide &

--- a/src/components/npFamilyMembers.ts
+++ b/src/components/npFamilyMembers.ts
@@ -1,5 +1,13 @@
 import {BaseComponent, Prettify} from '../base';
-import {ClearOnHide, Description, Hidden, IsSensitiveData, Label, Tooltip} from '../common';
+import {
+  ClearOnHide,
+  Description,
+  FAQItems,
+  Hidden,
+  IsSensitiveData,
+  Label,
+  Tooltip,
+} from '../common';
 import {Conditional, DisplayConfig, OFExtensions, Registration} from '../extensions';
 import {Validation} from '../validation';
 
@@ -25,6 +33,7 @@ export type NpFamilyMembersComponentSchema = Prettify<
     Label &
     Description &
     Tooltip &
+    FAQItems &
     DisplayConfig &
     Hidden &
     ClearOnHide &

--- a/src/components/number.ts
+++ b/src/components/number.ts
@@ -3,6 +3,7 @@ import {
   ClearOnHide,
   DefaultValue,
   Description,
+  FAQItems,
   Hidden,
   IsSensitiveData,
   Label,
@@ -54,6 +55,7 @@ export type NumberComponentSchema = Prettify<
     Label &
     Description &
     Tooltip &
+    FAQItems &
     NumberFieldExtras &
     DisplayConfig &
     Hidden &

--- a/src/components/partners.ts
+++ b/src/components/partners.ts
@@ -1,5 +1,13 @@
 import {BaseComponent, Prettify} from '../base';
-import {ClearOnHide, Description, Hidden, IsSensitiveData, Label, Tooltip} from '../common';
+import {
+  ClearOnHide,
+  Description,
+  FAQItems,
+  Hidden,
+  IsSensitiveData,
+  Label,
+  Tooltip,
+} from '../common';
 import {Conditional, OFExtensions, Registration} from '../extensions';
 
 export interface PartnerDetails {
@@ -32,6 +40,7 @@ export type PartnersComponentSchema = Prettify<
     Label &
     Description &
     Tooltip &
+    FAQItems &
     Hidden &
     ClearOnHide &
     IsSensitiveData &

--- a/src/components/phoneNumber.ts
+++ b/src/components/phoneNumber.ts
@@ -3,6 +3,7 @@ import {
   AutoComplete,
   ClearOnHide,
   Description,
+  FAQItems,
   Hidden,
   IsSensitiveData,
   Label,
@@ -26,6 +27,7 @@ export type PhoneNumberComponentSchema = Prettify<
     Label &
     Description &
     Tooltip &
+    FAQItems &
     DisplayConfig &
     Hidden &
     ClearOnHide &

--- a/src/components/postcode.ts
+++ b/src/components/postcode.ts
@@ -2,6 +2,7 @@ import {BaseComponent, Prettify, WithMultiple} from '../base';
 import {
   ClearOnHide,
   Description,
+  FAQItems,
   Hidden,
   IsSensitiveData,
   Label,
@@ -26,6 +27,7 @@ export type PostcodeComponentSchema = Prettify<
     Label &
     Description &
     Tooltip &
+    FAQItems &
     DisplayConfig &
     Hidden &
     ClearOnHide &

--- a/src/components/radio.ts
+++ b/src/components/radio.ts
@@ -3,6 +3,7 @@ import {
   ClearOnHide,
   DefaultValue,
   Description,
+  FAQItems,
   Hidden,
   IsSensitiveData,
   Label,
@@ -53,6 +54,7 @@ export type RadioComponentSchema = Prettify<
     Label &
     Description &
     Tooltip &
+    FAQItems &
     DisplayConfig &
     Hidden &
     ClearOnHide &

--- a/src/components/select.ts
+++ b/src/components/select.ts
@@ -1,5 +1,13 @@
 import {BaseComponent, Prettify, WithMultiple} from '../base';
-import {ClearOnHide, Description, Hidden, IsSensitiveData, Label, Tooltip} from '../common';
+import {
+  ClearOnHide,
+  Description,
+  FAQItems,
+  Hidden,
+  IsSensitiveData,
+  Label,
+  Tooltip,
+} from '../common';
 import {Conditional, DisplayConfig, OFExtensions, Registration} from '../extensions';
 import {ManualValues, Option, ReferenceListsValues, VariableValues} from '../options';
 import {Validation} from '../validation';
@@ -63,6 +71,7 @@ export type SelectComponentSchema = Prettify<
     Label &
     Description &
     Tooltip &
+    FAQItems &
     DisplayConfig &
     Hidden &
     ClearOnHide &

--- a/src/components/selectboxes.ts
+++ b/src/components/selectboxes.ts
@@ -3,6 +3,7 @@ import {
   ClearOnHide,
   DefaultValue,
   Description,
+  FAQItems,
   Hidden,
   IsSensitiveData,
   Label,
@@ -54,6 +55,7 @@ export type SelectboxesComponentSchema = Prettify<
     Label &
     Description &
     Tooltip &
+    FAQItems &
     DisplayConfig &
     Hidden &
     ClearOnHide &

--- a/src/components/signature.ts
+++ b/src/components/signature.ts
@@ -1,5 +1,13 @@
 import {BaseComponent, Prettify} from '../base';
-import {ClearOnHide, Description, Hidden, IsSensitiveData, Label, Tooltip} from '../common';
+import {
+  ClearOnHide,
+  Description,
+  FAQItems,
+  Hidden,
+  IsSensitiveData,
+  Label,
+  Tooltip,
+} from '../common';
 import {Conditional, DisplayConfig, OFExtensions, Registration} from '../extensions';
 import {Validation} from '../validation';
 
@@ -28,6 +36,7 @@ export type SignatureComponentSchema = Prettify<
     Label &
     Description &
     Tooltip &
+    FAQItems &
     DisplayConfig &
     Hidden &
     ClearOnHide &

--- a/src/components/textarea.ts
+++ b/src/components/textarea.ts
@@ -3,6 +3,7 @@ import {
   AutoComplete,
   ClearOnHide,
   Description,
+  FAQItems,
   Hidden,
   IsSensitiveData,
   Label,
@@ -40,6 +41,7 @@ export type TextareaComponentSchema = Prettify<
     Label &
     Description &
     Tooltip &
+    FAQItems &
     DisplayConfig &
     Hidden &
     ClearOnHide &

--- a/src/components/textfield.ts
+++ b/src/components/textfield.ts
@@ -3,6 +3,7 @@ import {
   AutoComplete,
   ClearOnHide,
   Description,
+  FAQItems,
   Hidden,
   IsSensitiveData,
   Label,
@@ -30,6 +31,7 @@ export type TextFieldComponentSchema = Prettify<
     Label &
     Description &
     Tooltip &
+    FAQItems &
     DisplayConfig &
     Hidden &
     ClearOnHide &

--- a/src/components/time.ts
+++ b/src/components/time.ts
@@ -2,6 +2,7 @@ import {BaseComponent, Prettify, WithMultiple} from '../base';
 import {
   ClearOnHide,
   Description,
+  FAQItems,
   Hidden,
   IsSensitiveData,
   Label,
@@ -32,6 +33,7 @@ export type TimeComponentSchema = Prettify<
     Label &
     Description &
     Tooltip &
+    FAQItems &
     DisplayConfig &
     Hidden &
     ClearOnHide &


### PR DESCRIPTION
Closes the following bullet point in https://github.com/orgs/open-formulieren/projects/2/views/44?pane=issue&itemId=192214406&issue=open-formulieren%7Copen-forms%7C6315: 
>  Update field component schemas to include newly configurable tool tip related fields