### PR TITLE
Drop support for file component-level registration options

### DIFF
--- a/src/components/file.ts
+++ b/src/components/file.ts
@@ -157,45 +157,6 @@ interface FileExtras {
    * To be moved in the `validate` configuration options?
    */
   maxNumberOfFiles?: number | null;
-
-  /**
-   * Custom registration options for registration plugins.
-   *
-   * @deprecated
-   * This will be moved to a dedicated section in the new admin UI and removed from the
-   * component configuration, as it doesn't play well with multiple registration backend
-   * configurations/options at the form level.
-   */
-  registration?: {
-    bronorganisatie?: string;
-    docVertrouwelijkheidaanduiding?: string;
-    titel?: string;
-
-    /**
-     * Configuration to resolve the document type to use. Replaces the
-     * `informatieobjecttype` fixed URL reference.
-     *
-     * See the `ZaakOptionsSerializer` serializer in the backend for prior art and usage.
-     */
-    documentType?: {
-      catalogue: {
-        domain: string;
-        rsin: string;
-      };
-      /**
-       * Description of the document type to use. The backend will resolve it at runtime
-       * and automatically select the appropriate version. It is looked up within the
-       * specified catalogue.
-       */
-      description: string;
-    };
-    /**
-     * URL reference to the informatieobjecttype in the Catalogi API.
-     *
-     * @deprecated Deprecated in favour of the catalogue + description references.
-     */
-    informatieobjecttype?: string;
-  };
 }
 
 interface FileExtensions {

--- a/test-d/formio/components/file.test-d.ts
+++ b/test-d/formio/components/file.test-d.ts
@@ -33,12 +33,6 @@ expectAssignable<FileComponentSchema>({
     allowedTypesLabels: ['.png', '.pdf'],
   },
   useConfigFiletypes: false, // custom option to dynamically set allowed file types
-  registration: {
-    informatieobjecttype: '',
-    bronorganisatie: '',
-    docVertrouwelijkheidaanduiding: '',
-    titel: '',
-  },
   openForms: {
     translations: {},
   },
@@ -111,20 +105,6 @@ expectAssignable<FileComponentSchema>({
   filePattern: 'image/png,application/pdf',
   fileMaxSize: '10MB',
   maxNumberOfFiles: 3, // custom setting
-  // registration tab in builder form
-  registration: {
-    bronorganisatie: '',
-    docVertrouwelijkheidaanduiding: 'openbaar',
-    titel: '',
-    informatieobjecttype: '',
-    documentType: {
-      catalogue: {
-        rsin: '000000000',
-        domain: 'VTH',
-      },
-      description: 'Attachment',
-    },
-  },
   // (mostly) translations tab in builder form
   openForms: {
     softRequired: true,


### PR DESCRIPTION
Partly closes open-formulieren/open-forms#6281

This has been moved into the registration backend options in the backend project.