### PR TITLE
[#6315] Fix naming for openForms option for faq items

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -39,7 +39,7 @@ export type FAQItem = {
    * Rich text content, displayed in a modal after interacting with the label.
    */
   content: string;
-  openforms?: {
+  openForms?: {
     /**
      * Translations for the user-facing texts. The backend processes this and assigns
      * the matching top-level properties.


### PR DESCRIPTION
This follows [the existing naming scheme](https://github.com/open-formulieren/open-forms/blob/f1541e1924f916308f8adef3a0e110bb89d42e1e/src/openforms/formio/registry.py#L370) for openforms related configurations inside components.