### PR TITLE
[#6315] export FAQ types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from './json';
 export {Option} from './options';
 export {SupportedLocales} from './i18n';
+export {FAQItems, FAQItem} from './common';
 export * from './components';


### PR DESCRIPTION
This allows users to import these types from the package instead of from the @open-formulieren/types/dist/common path. See https://github.com/open-formulieren/formio-renderer/pull/335#discussion_r3535736061 for more context.