### PR TITLE
[open-formulieren/open-forms#6315] add id attribute to FAQ item type

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -32,6 +32,10 @@ export type Tooltip = {
 
 export type FAQItem = {
   /**
+   * Unique ID for a FAQ item in a list of FAQ items. Used to render unique HTML elements.
+   */
+  id: string;
+  /**
    * Short interactive label. Interacting will result in the content being displayed.
    */
   label: string;


### PR DESCRIPTION
This PR adds the `id` attribute [as discussed in this comment](https://github.com/open-formulieren/formio-builder/pull/300/changes#r3728071415) as part of a review in the formio-builder.